### PR TITLE
Fixed Chia RPC port conflict

### DIFF
--- a/spare/util/initial-config.yaml
+++ b/spare/util/initial-config.yaml
@@ -358,7 +358,7 @@ introducer:
 
 wallet:
   port: 9449
-  rpc_port: 9256
+  rpc_port: 7256
 
   # The minimum height that we care about for our transactions. Set to zero
   # If we are restoring from private key and don't know the height.


### PR DESCRIPTION
I've updated the wallet RPC port number to something that isn't used by Chia, flax, goji, hddcoin, chaingreen, seno, equality, flora, or thyme. Feel free to choose a different port.