### PR TITLE
Fix WSChiaConnection typo

### DIFF
--- a/spare/full_node/full_node.py
+++ b/spare/full_node/full_node.py
@@ -338,7 +338,7 @@ class FullNode:
             await asyncio.sleep(sleep_before)
         self._state_changed("peer_changed_peak")
 
-    async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSSpareConnection):
+    async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSspareConnection):
         """
         We have received a notification of a new peak from a peer. This happens either when we have just connected,
         or when the peer has updated their peak.

--- a/spare/full_node/full_node.py
+++ b/spare/full_node/full_node.py
@@ -338,7 +338,7 @@ class FullNode:
             await asyncio.sleep(sleep_before)
         self._state_changed("peer_changed_peak")
 
-    async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSChiaConnection):
+    async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSSpareConnection):
         """
         We have received a notification of a new peak from a peer. This happens either when we have just connected,
         or when the peer has updated their peak.

--- a/spare/server/server.py
+++ b/spare/server/server.py
@@ -374,7 +374,7 @@ class spareServer:
             if peer_id == self.node_id:
                 raise RuntimeError(f"Trying to connect to a peer ({target_node}) with the same peer_id: {peer_id}")
 
-            connection = WSChiaConnection(
+            connection = WSspareConnection(
                 self._local_type,
                 ws,
                 self._port,


### PR DESCRIPTION
It looks like there may have been a small oversight in regard to the lack of replacement of "Chia" with "Spare" here.